### PR TITLE
Opting out of `-o default -o bashdefault` in generating completion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ It currently supports the following shells:
 
 See [the code of the sample app](./example/greet.go) for how to use the library.
 
+For the `Completion` subcommand, you can specify the following parameters in the annotation:
+
+- `completion-shell-default`
+  - Whether completions should fall back to the shell’s default ones, e.g. to complete file paths.
+  - Possible values: `true`, `false`
+  - Default value: `true`
+  - Usage example: `completion-shell-default:"false"`
+
 In case you want to compile and run the demo app, keep in mind that completions only work for binaries in your $PATH, not for local ones (e.g. with `./` prefix).
 
 ## About

--- a/completion.go
+++ b/completion.go
@@ -19,12 +19,6 @@ type Completion struct {
 	Code  bool   `short:"c" help:"Generate the initialization code"`
 }
 
-// CompletionNoFileComp is a kong subcommand that is similar to [Completion]
-// but does not enable file completion per default for all commands.
-type CompletionNoFileComp struct {
-	Completion
-}
-
 // Help is a predefined kong method for printing the help text.
 func (c *Completion) Help() string {
 	return `

--- a/example/greet.go
+++ b/example/greet.go
@@ -34,9 +34,7 @@ func main() {
 	}
 }
 
-// GreetingApp is a sample app. The `Completion` subcommand is optional; it’s purpose is
-// to help the user to configure the completions for their shell. (The completions themselves
-// would work without this command, though.)
+// GreetingApp is a sample app.
 type GreetingApp struct {
 	Hello      Hello                     `cmd:"" help:"Prints a greeting"`
 	Completion kongcompletion.Completion `cmd:"" help:"Outputs shell code for initialising tab completions"`

--- a/example/greet.go
+++ b/example/greet.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/alecthomas/kong"
-	"github.com/jotaen/kong-completion"
-	"github.com/posener/complete"
 	"os"
 	"strings"
+
+	"github.com/alecthomas/kong"
+	kongcompletion "github.com/jotaen/kong-completion"
+	"github.com/posener/complete"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/alecthomas/kong v0.7.1
-	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
 	github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab
 	github.com/stretchr/testify v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=

--- a/prediction.go
+++ b/prediction.go
@@ -117,6 +117,7 @@ func Register(parser *kong.Kong, opt ...Option) {
 		errHandler(err)
 		exitFunc(1)
 	}
+
 	cmp := complete.New(parser.Model.Name, cmd)
 	cmp.Out = parser.Stdout
 	done := cmp.Complete()

--- a/shells.go
+++ b/shells.go
@@ -24,7 +24,7 @@ var shells = map[string]shell{
 	fish.name: fish,
 }
 
-func newShellFromString(shellName string, noDefaultFileComp bool) (shell, error) {
+func newShellFromString(shellName string) (shell, error) {
 	sh, ok := shells[shellName]
 	if !ok {
 		return shell{}, errors.New("")

--- a/shells.go
+++ b/shells.go
@@ -1,7 +1,7 @@
 package kongcompletion
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 type shell struct {
@@ -24,7 +24,7 @@ var shells = map[string]shell{
 	fish.name: fish,
 }
 
-func newShellFromString(shellName string) (shell, error) {
+func newShellFromString(shellName string, noDefaultFileComp bool) (shell, error) {
 	sh, ok := shells[shellName]
 	if !ok {
 		return shell{}, errors.New("")
@@ -34,7 +34,7 @@ func newShellFromString(shellName string) (shell, error) {
 
 var bash = shell{
 	name:            "bash",
-	initCode:        tmpl(`complete -o default -o bashdefault -C {{.BinPath}} {{.BinName}}`),
+	initCode:        tmpl(`complete {{.Options}} -C {{.BinPath}} {{.BinName}}`),
 	dynamicInitCode: tmpl(`source <({{.BinName}} {{.SubCmdName}} -c bash)`),
 	initFilePath:    "~/.bashrc",
 }
@@ -42,7 +42,7 @@ var bash = shell{
 var zsh = shell{
 	name: "zsh",
 	initCode: tmpl(`autoload -U +X bashcompinit && bashcompinit
-complete -o default -o bashdefault -C {{.BinPath}} {{.BinName}}`),
+complete {{.Options}} -C {{.BinPath}} {{.BinName}}`),
 	dynamicInitCode: tmpl(`source <({{.BinName}} {{.SubCmdName}} -c zsh)`),
 	initFilePath:    "~/.zshrc",
 }

--- a/shells.go
+++ b/shells.go
@@ -8,11 +8,12 @@ type shell struct {
 	// name is the name of the shell
 	name string
 
-	// initCode is a template for the shell initialization code.
+	// initCode is the actual code that registers the completion in the shell.
 	initCode *template
 
-	// dynamicInitCode is a template for the command that prints the shell initialization code.
-	dynamicInitCode *template
+	// configFileCode is the code that the user is supposed to put in
+	// their shell config file, e.g. ~/.bashrc
+	configFileCode *template
 
 	// initFilePath is the path of the shell’s default init file, e.g. ~/.bashrc
 	initFilePath string
@@ -33,18 +34,18 @@ func newShellFromString(shellName string) (shell, error) {
 }
 
 var bash = shell{
-	name:            "bash",
-	initCode:        tmpl(`complete {{.Options}} -C {{.BinPath}} {{.BinName}}`),
-	dynamicInitCode: tmpl(`source <({{.BinName}} {{.SubCmdName}} -c bash)`),
-	initFilePath:    "~/.bashrc",
+	name:           "bash",
+	initCode:       tmpl(`complete{{if .UseShellDefault}} -o default -o bashdefault{{ end }} -C {{.BinPath}} {{.BinName}}`),
+	configFileCode: tmpl(`source <({{.BinName}} {{.SubCmdName}} -c bash)`),
+	initFilePath:   "~/.bashrc",
 }
 
 var zsh = shell{
 	name: "zsh",
 	initCode: tmpl(`autoload -U +X bashcompinit && bashcompinit
-complete {{.Options}} -C {{.BinPath}} {{.BinName}}`),
-	dynamicInitCode: tmpl(`source <({{.BinName}} {{.SubCmdName}} -c zsh)`),
-	initFilePath:    "~/.zshrc",
+complete{{if .UseShellDefault}} -o default -o bashdefault{{ end }} -C {{.BinPath}} {{.BinName}}`),
+	configFileCode: tmpl(`source <({{.BinName}} {{.SubCmdName}} -c zsh)`),
+	initFilePath:   "~/.zshrc",
 }
 
 var fish = shell{
@@ -56,6 +57,6 @@ var fish = shell{
     {{.BinPath}}
 end
 complete -f -c {{.BinName}} -a "(__complete_{{.BinName}})"`),
-	dynamicInitCode: tmpl(`{{.BinName}} {{.SubCmdName}} -c fish | source`),
-	initFilePath:    "~/.config/fish/config.fish",
+	configFileCode: tmpl(`{{.BinName}} {{.SubCmdName}} -c fish | source`),
+	initFilePath:   "~/.config/fish/config.fish",
 }

--- a/template.go
+++ b/template.go
@@ -5,11 +5,11 @@ import (
 	gotemplate "text/template"
 )
 
-type binaryInfo struct {
-	BinName    string // The canonical name of the binary, e.g. `greet`
-	BinPath    string // The full path to the binary, e.g. `/usr/bin/greet`
-	SubCmdName string // The name of the invoked subcommand, e.g. `completion` for `greet completion`.
-	Options    string // Options supplied to complete command
+type templateData struct {
+	BinName         string // The canonical name of the binary, e.g. `greet`
+	BinPath         string // The full path to the binary, e.g. `/usr/bin/greet`
+	SubCmdName      string // The name of the invoked subcommand, e.g. `completion` for `greet completion`.
+	UseShellDefault bool   // Whether to fall back to default shell completions.
 }
 
 type template gotemplate.Template
@@ -23,7 +23,7 @@ func tmpl(tmpl string) *template {
 	return (*template)(t)
 }
 
-func (bi binaryInfo) fill(t *template) string {
+func (bi templateData) fill(t *template) string {
 	result := &bytes.Buffer{}
 	err := (*gotemplate.Template)(t).Execute(result, bi)
 	if err != nil {

--- a/template.go
+++ b/template.go
@@ -9,6 +9,7 @@ type binaryInfo struct {
 	BinName    string // The canonical name of the binary, e.g. `greet`
 	BinPath    string // The full path to the binary, e.g. `/usr/bin/greet`
 	SubCmdName string // The name of the invoked subcommand, e.g. `completion` for `greet completion`.
+	Options    string // Options supplied to complete command
 }
 
 type template gotemplate.Template


### PR DESCRIPTION
Resolves https://github.com/jotaen/kong-completion/issues/2.

This introduces a new `CompletionNoFileComp` command, which can be used to skip the above parameters.