### PR TITLE
Allow kong interpolations in predictor tags

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -1,0 +1,45 @@
+package kongcompletion
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/alecthomas/kong"
+)
+
+var interpolationRegex = regexp.MustCompile(`(\$\$)|((?:\${([[:alpha:]_][[:word:]]*))(?:=([^}]+))?})|(\$)|([^$]+)`)
+
+// Interpolate variables from vars into s for substrings in the form ${var} or ${var=default}.
+//
+// This logic is forked from kong's interpolate.go to allow performing interpolation here.
+func interpolate(s string, vars kong.Vars, updatedVars map[string]string) (string, error) {
+	out := ""
+	matches := interpolationRegex.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 {
+		return s, nil
+	}
+	for key, val := range updatedVars {
+		if vars[key] != val {
+			vars = vars.CloneWith(updatedVars)
+			break
+		}
+	}
+	for _, match := range matches {
+		if dollar := match[1]; dollar != "" {
+			out += "$"
+		} else if name := match[3]; name != "" {
+			value, ok := vars[name]
+			if !ok {
+				// No default value.
+				if match[4] == "" {
+					return "", fmt.Errorf("undefined variable ${%s}", name)
+				}
+				value = match[4]
+			}
+			out += value
+		} else {
+			out += match[0]
+		}
+	}
+	return out, nil
+}

--- a/interpolate.go
+++ b/interpolate.go
@@ -1,3 +1,27 @@
+// This code is copied over from kong to allow performing interpolation here.
+// (The original function is not exported.)
+// See https://github.com/alecthomas/kong/blob/master/interpolate.go
+//
+// Copyright (C) 2018 Alec Thomas (https://github.com/alecthomas/kong)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package kongcompletion
 
 import (
@@ -10,8 +34,6 @@ import (
 var interpolationRegex = regexp.MustCompile(`(\$\$)|((?:\${([[:alpha:]_][[:word:]]*))(?:=([^}]+))?})|(\$)|([^$]+)`)
 
 // Interpolate variables from vars into s for substrings in the form ${var} or ${var=default}.
-//
-// This logic is forked from kong's interpolate.go to allow performing interpolation here.
 func interpolate(s string, vars kong.Vars, updatedVars map[string]string) (string, error) {
 	out := ""
 	matches := interpolationRegex.FindAllStringSubmatch(s, -1)

--- a/prediction_test.go
+++ b/prediction_test.go
@@ -40,12 +40,13 @@ func TestComplete(t *testing.T) {
 			Duck     struct{} `kong:"cmd"`
 		} `kong:"cmd"`
 		Bar struct {
-			Tiger   string `kong:"arg,predictor=things"`
-			Bear    string `kong:"arg,predictor=otherthings"`
-			OMG     string `kong:"required,enum='oh,my,gizzles'"`
-			Number  int    `kong:"required,short=n,enum='1,2,3'"`
-			BooFlag bool   `kong:"name=boofl,short=b"`
-		} `kong:"cmd"`
+			Tiger    string `kong:"arg,predictor=things"`
+			Bear     string `kong:"arg,predictor=otherthings"`
+			Elephant string `kong:"arg,predictor=${a}${b},set=b=things"`
+			OMG      string `kong:"required,enum='oh,my,gizzles'"`
+			Number   int    `kong:"required,short=n,enum='1,2,3'"`
+			BooFlag  bool   `kong:"name=boofl,short=b"`
+		} `kong:"cmd,set=a=other"`
 		Baz struct{} `kong:"cmd,hidden"`
 	}
 
@@ -166,26 +167,33 @@ func TestComplete(t *testing.T) {
 
 func Test_tagPredictor(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
-		got, err := tagPredictor(nil, nil)
+		got, err := tagPredictor(nil, nil, nil)
 		assert.NoError(t, err)
 		assert.Nil(t, got)
 	})
 
 	t.Run("no predictor tag", func(t *testing.T) {
-		got, err := tagPredictor(testTag{}, nil)
+		got, err := tagPredictor(testTag{}, nil, nil)
 		assert.NoError(t, err)
 		assert.Nil(t, got)
 	})
 
 	t.Run("missing predictor", func(t *testing.T) {
-		got, err := tagPredictor(testTag{predictorTag: "foo"}, nil)
+		got, err := tagPredictor(testTag{predictorTag: "foo"}, nil, nil)
 		assert.Error(t, err)
-		assert.Equal(t, `no predictor with name "foo"`, err.Error())
+		assert.ErrorContains(t, err, `no predictor with name "foo"`)
 		assert.Nil(t, got)
 	})
 
 	t.Run("existing predictor", func(t *testing.T) {
-		got, err := tagPredictor(testTag{predictorTag: "foo"}, map[string]complete.Predictor{"foo": complete.PredictAnything})
+		got, err := tagPredictor(testTag{predictorTag: "foo"}, map[string]complete.Predictor{"foo": complete.PredictAnything}, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, got)
+	})
+
+	t.Run("interpolation", func(t *testing.T) {
+		vars := kong.Vars{"VAR": "foo"}
+		got, err := tagPredictor(testTag{predictorTag: "${VAR}"}, map[string]complete.Predictor{"foo": complete.PredictAnything}, vars)
 		assert.NoError(t, err)
 		assert.NotNil(t, got)
 	})


### PR DESCRIPTION
Another PR of things I found useful and was interested in upstreaming.

In this one, I found it useful to be able to use [kong variable interpolations](https://github.com/alecthomas/kong#variable-interpolation) in the predictor tags. For cases where there's a generic kong command that's then extended using `set` tags, this allows changing how the completion works for all of those.