### PR TITLE
Refactor mechanism for completion eligibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,25 @@ It currently supports the following shells:
 
 See [the code of the sample app](./example/greet.go) for how to use the library.
 
-For the `Completion` subcommand, you can specify the following parameters in the annotation:
+In case you want to compile and run the demo app, keep in mind that completions only work for binaries in your $PATH, not for local ones (e.g. with `./` prefix). You also have to activate the completions first.
+
+## API Reference
+
+For flags and commands of your kong app, you can specify the following parameters in the annotation:
+
+- `completion-enabled`
+  - Whether this command or flag should be eligible for completions. By default, all flags and commands are eligible unless they are hidden. You can override this behaviour via this annotation parameter.
+  - Possible values: `true`, `false`
+  - Default value: derived from kong’s `hidden` flag – i.e., if the flag is hidden, it by default isn’t available for completion.
+  - Usage example: `completion-enabled:"true"`
+
+For the `Completion` subcommand specifically (as provided by this library), you can specify the following parameters in the annotation:
 
 - `completion-shell-default`
-  - Whether completions should fall back to the shell’s default ones, e.g. to complete file paths.
+  - Whether completions should fall back to the shell’s default completion behaviour, e.g. to complete file paths.
   - Possible values: `true`, `false`
   - Default value: `true`
   - Usage example: `completion-shell-default:"false"`
-
-In case you want to compile and run the demo app, keep in mind that completions only work for binaries in your $PATH, not for local ones (e.g. with `./` prefix).
 
 ## About
 

--- a/prediction_test.go
+++ b/prediction_test.go
@@ -36,9 +36,10 @@ func TestComplete(t *testing.T) {
 			Tata     string   `kong:"aliases=titi"`        // one alias
 			Xuxu     string   `kong:"aliases='xoxo,xixi'"` // multiple aliases
 			Qux      bool     `kong:"hidden"`              // regular hidden
-			Quy      bool     // hidden via override option
-			Quz      bool     `kong:"hidden"` // unhidden via override option
+			Quy      bool     `kong:"completion-enabled=false"`
+			Quz      bool     `kong:"hidden,completion-enabled=true"`
 			Rabbit   struct{} `kong:"cmd"`
+			Eagle    struct{} `kong:"cmd,completion-enabled=false"`
 			Duck     struct{} `kong:"cmd,aliases=bird"`
 		} `kong:"cmd"`
 		Bar struct {
@@ -173,10 +174,6 @@ func TestComplete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			options := []Option{
 				WithPredictors(predictors),
-				WithFlagOverrides(map[string]bool{
-					"quy": false,
-					"quz": true,
-				}),
 			}
 			got := runComplete(t, td.parser, td.line, options)
 			assert.ElementsMatch(t, td.want, got)


### PR DESCRIPTION
This PR abandons the previous `WithFlagOverrides` method with an annotation parameter.

In a nutshell, all flags and commands are eligible for tab completion unless they are hidden. Before, you could override this behaviour via the map passed to `WithFlagOverrides`. This is a pretty inelegant solution.

As of this change, you can specify an annotation parameter directly on the flag or command, e.g.:

```go
type Demo struct {
	Foo string // --foo shows up in the completions list
	Bar string `hidden:""` // --bar doesn’t show up in the completions list, because it’s hidden
	Abc string `hidden:"" completion-enabled:"true"` // --abc shows up, even though it’s hidden
	Xyz string `completion-enabled:"false"` // --xyz doesn’t show up, even though it’s visible
}
```