### PR TITLE
Rename predictor annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,19 @@ In case you want to compile and run the demo app, keep in mind that completions 
 
 For flags and commands of your kong app, you can specify the following parameters in the annotation:
 
-- `completion-enabled`
+- `completion-enabled` (optional)
   - Whether this command or flag should be eligible for completions. By default, all flags and commands are eligible unless they are hidden. You can override this behaviour via this annotation parameter.
   - Possible values: `true`, `false`
   - Default value: derived from kong’s `hidden` flag – i.e., if the flag is hidden, it by default isn’t available for completion.
   - Usage example: `completion-enabled:"true"`
+- `completion-predictor` (optional)
+  - Which completion predictor to use for completing this argument.
+  - Possible values: any predictor name that is registered via the `WithPredictor` method.
+  - Usage example: `completion-predictor:"zipcode"`
 
 For the `Completion` subcommand specifically (as provided by this library), you can specify the following parameters in the annotation:
 
-- `completion-shell-default`
+- `completion-shell-default` (optional)
   - Whether completions should fall back to the shell’s default completion behaviour, e.g. to complete file paths.
   - Possible values: `true`, `false`
   - Default value: `true`

--- a/example/greet.go
+++ b/example/greet.go
@@ -43,7 +43,7 @@ type GreetingApp struct {
 type Hello struct {
 	Strong bool   `help:"Print the greeting in ALL CAPS!!!"`
 	Casual bool   `help:"In case you are more laid back, you know"`
-	Name   string `arg:"" help:"Personalize the greeting with your name!" predictor:"name" default:"World"`
+	Name   string `arg:"" help:"Personalize the greeting with your name!" completion-predictor:"name" default:"World"`
 }
 
 // Custom predictor. (Just as demo how these works.)

--- a/prediction.go
+++ b/prediction.go
@@ -8,7 +8,10 @@ import (
 	"github.com/posener/complete"
 )
 
-const predictorTag = "predictor"
+const (
+	predictorTag = "completion-predictor"
+	enabledTag   = "completion-enabled"
+)
 
 type options struct {
 	predictors   map[string]complete.Predictor
@@ -168,13 +171,12 @@ func nodeCommand(node *kong.Node, opts *options, vars kong.Vars, flags flags) (*
 }
 
 func isCompletionEnabled(tag *kong.Tag) bool {
-	for _, i := range tag.GetAll("completion-enabled") {
-		if i == "false" {
-			return false
-		}
-		if i == "true" {
-			return true
-		}
+	v := tag.Get(enabledTag)
+	if v == "false" {
+		return false
+	}
+	if v == "true" {
+		return true
 	}
 	return !tag.Hidden
 }

--- a/prediction_test.go
+++ b/prediction_test.go
@@ -31,7 +31,7 @@ func TestComplete(t *testing.T) {
 	var cli struct {
 		Foo struct {
 			Embedded embed  `kong:"embed"`
-			Bar      string `kong:"predictor=things"`
+			Bar      string `kong:"completion-predictor=things"`
 			Baz      bool
 			Tata     string   `kong:"aliases=titi"`        // one alias
 			Xuxu     string   `kong:"aliases='xoxo,xixi'"` // multiple aliases
@@ -43,9 +43,9 @@ func TestComplete(t *testing.T) {
 			Duck     struct{} `kong:"cmd,aliases=bird"`
 		} `kong:"cmd"`
 		Bar struct {
-			Tiger    string `kong:"arg,predictor=things"`
-			Bear     string `kong:"arg,predictor=otherthings"`
-			Elephant string `kong:"arg,predictor=${a}${b},set=b=things"`
+			Tiger    string `kong:"arg,completion-predictor=things"`
+			Bear     string `kong:"arg,completion-predictor=otherthings"`
+			Elephant string `kong:"arg,completion-predictor=${a}${b},set=b=things"`
 			OMG      string `kong:"required,enum='oh,my,gizzles'"`
 			Number   int    `kong:"required,short=n,enum='1,2,3'"`
 			BooFlag  bool   `kong:"name=boofl,short=b"`


### PR DESCRIPTION
This PR renames the `predictor` annotation parameter to `completion-predictor`. That way, all completion-related annotation parameters share the common `completion-` prefix.