### PR TITLE
Fix variadic positional args completing only first value

### DIFF
--- a/positional_predictor.go
+++ b/positional_predictor.go
@@ -8,10 +8,10 @@ import (
 
 // PositionalPredictor is a predictor for positional arguments
 type PositionalPredictor struct {
-	Predictors     []complete.Predictor
-	ArgFlags       []string
-	BoolFlags      []string
-	LastIsVariadic bool
+	Predictors           []complete.Predictor
+	ArgFlags             []string
+	BoolFlags            []string
+	LastFlagIsCumulative bool // “Cumulative” means the last flag can appear multiple times.
 }
 
 // Predict implements complete.Predict
@@ -27,7 +27,7 @@ func (p *PositionalPredictor) predictor(a complete.Args) complete.Predictor {
 	position := p.predictorIndex(a)
 	complete.Log("predicting positional argument(%d)", position)
 	if position < 0 || position > len(p.Predictors)-1 {
-		if p.LastIsVariadic && len(p.Predictors) > 0 {
+		if p.LastFlagIsCumulative && len(p.Predictors) > 0 {
 			return p.Predictors[len(p.Predictors)-1]
 		}
 		return nil

--- a/positional_predictor.go
+++ b/positional_predictor.go
@@ -8,9 +8,10 @@ import (
 
 // PositionalPredictor is a predictor for positional arguments
 type PositionalPredictor struct {
-	Predictors []complete.Predictor
-	ArgFlags   []string
-	BoolFlags  []string
+	Predictors     []complete.Predictor
+	ArgFlags       []string
+	BoolFlags      []string
+	LastIsVariadic bool
 }
 
 // Predict implements complete.Predict
@@ -26,6 +27,9 @@ func (p *PositionalPredictor) predictor(a complete.Args) complete.Predictor {
 	position := p.predictorIndex(a)
 	complete.Log("predicting positional argument(%d)", position)
 	if position < 0 || position > len(p.Predictors)-1 {
+		if p.LastIsVariadic && len(p.Predictors) > 0 {
+			return p.Predictors[len(p.Predictors)-1]
+		}
 		return nil
 	}
 	return p.Predictors[position]

--- a/positional_predictor_test.go
+++ b/positional_predictor_test.go
@@ -55,6 +55,61 @@ func TestPositionalPredictor_predictor(t *testing.T) {
 	}
 }
 
+func TestPositionalPredictor_predictor_variadic(t *testing.T) {
+	predictor1 := complete.PredictSet("1")
+	predictor2 := complete.PredictSet("2")
+
+	t.Run("two predictors last variadic", func(t *testing.T) {
+		posPredictor := &PositionalPredictor{
+			Predictors:     []complete.Predictor{predictor1, predictor2},
+			LastIsVariadic: true,
+		}
+		for args, want := range map[string]complete.Predictor{
+			``:              predictor1,
+			`foo`:           predictor1,
+			`foo `:          predictor2,
+			`foo bar`:       predictor2,
+			`foo bar `:      predictor2,
+			`foo bar baz`:   predictor2,
+			`foo bar baz  `: predictor2,
+		} {
+			t.Run(args, func(t *testing.T) {
+				got := posPredictor.predictor(newArgs("app " + args))
+				assert.Equal(t, want, got)
+			})
+		}
+	})
+
+	t.Run("single predictor variadic", func(t *testing.T) {
+		posPredictor := &PositionalPredictor{
+			Predictors:     []complete.Predictor{predictor1},
+			LastIsVariadic: true,
+		}
+		for args, want := range map[string]complete.Predictor{
+			``:            predictor1,
+			`foo`:         predictor1,
+			`foo `:        predictor1,
+			`foo bar`:     predictor1,
+			`foo bar `:    predictor1,
+			`foo bar baz`: predictor1,
+		} {
+			t.Run(args, func(t *testing.T) {
+				got := posPredictor.predictor(newArgs("app " + args))
+				assert.Equal(t, want, got)
+			})
+		}
+	})
+
+	t.Run("not variadic still returns nil", func(t *testing.T) {
+		posPredictor := &PositionalPredictor{
+			Predictors:     []complete.Predictor{predictor1, predictor2},
+			LastIsVariadic: false,
+		}
+		got := posPredictor.predictor(newArgs("app foo bar "))
+		assert.Nil(t, got)
+	})
+}
+
 // The code below is taken from https://github.com/posener/complete/blob/f6dd29e97e24f8cb51a8d4050781ce2b238776a4/args.go
 // to assist in tests.
 

--- a/positional_predictor_test.go
+++ b/positional_predictor_test.go
@@ -55,14 +55,14 @@ func TestPositionalPredictor_predictor(t *testing.T) {
 	}
 }
 
-func TestPositionalPredictor_predictor_variadic(t *testing.T) {
+func TestPositionalPredictor_predictor_cumulative(t *testing.T) {
 	predictor1 := complete.PredictSet("1")
 	predictor2 := complete.PredictSet("2")
 
-	t.Run("two predictors last variadic", func(t *testing.T) {
+	t.Run("two predictors, last flag is cumulative", func(t *testing.T) {
 		posPredictor := &PositionalPredictor{
-			Predictors:     []complete.Predictor{predictor1, predictor2},
-			LastIsVariadic: true,
+			Predictors:           []complete.Predictor{predictor1, predictor2},
+			LastFlagIsCumulative: true,
 		}
 		for args, want := range map[string]complete.Predictor{
 			``:              predictor1,
@@ -80,10 +80,10 @@ func TestPositionalPredictor_predictor_variadic(t *testing.T) {
 		}
 	})
 
-	t.Run("single predictor variadic", func(t *testing.T) {
+	t.Run("single predictor (cumulative)", func(t *testing.T) {
 		posPredictor := &PositionalPredictor{
-			Predictors:     []complete.Predictor{predictor1},
-			LastIsVariadic: true,
+			Predictors:           []complete.Predictor{predictor1},
+			LastFlagIsCumulative: true,
 		}
 		for args, want := range map[string]complete.Predictor{
 			``:            predictor1,
@@ -100,10 +100,10 @@ func TestPositionalPredictor_predictor_variadic(t *testing.T) {
 		}
 	})
 
-	t.Run("not variadic still returns nil", func(t *testing.T) {
+	t.Run("non-cumulative returns nil (i.e., does not predict anything)", func(t *testing.T) {
 		posPredictor := &PositionalPredictor{
-			Predictors:     []complete.Predictor{predictor1, predictor2},
-			LastIsVariadic: false,
+			Predictors:           []complete.Predictor{predictor1, predictor2},
+			LastFlagIsCumulative: false,
 		}
 		got := posPredictor.predictor(newArgs("app foo bar "))
 		assert.Nil(t, got)

--- a/prediction.go
+++ b/prediction.go
@@ -161,12 +161,12 @@ func nodeCommand(node *kong.Node, opts *options, vars kong.Vars, flags flags) (*
 	if err != nil {
 		return nil, err
 	}
-	lastIsVariadic := len(node.Positional) > 0 && node.Positional[len(node.Positional)-1].IsCumulative()
+	lastIsCumulative := len(node.Positional) > 0 && node.Positional[len(node.Positional)-1].IsCumulative()
 	cmd.Args = &PositionalPredictor{
-		Predictors:     pps,
-		ArgFlags:       flagNamesWithHyphens(flags.argFlags...),
-		BoolFlags:      flagNamesWithHyphens(flags.boolFlags...),
-		LastIsVariadic: lastIsVariadic,
+		Predictors:           pps,
+		ArgFlags:             flagNamesWithHyphens(flags.argFlags...),
+		BoolFlags:            flagNamesWithHyphens(flags.boolFlags...),
+		LastFlagIsCumulative: lastIsCumulative,
 	}
 
 	return &cmd, nil

--- a/prediction.go
+++ b/prediction.go
@@ -161,10 +161,12 @@ func nodeCommand(node *kong.Node, opts *options, vars kong.Vars, flags flags) (*
 	if err != nil {
 		return nil, err
 	}
+	lastIsVariadic := len(node.Positional) > 0 && node.Positional[len(node.Positional)-1].IsCumulative()
 	cmd.Args = &PositionalPredictor{
-		Predictors: pps,
-		ArgFlags:   flagNamesWithHyphens(flags.argFlags...),
-		BoolFlags:  flagNamesWithHyphens(flags.boolFlags...),
+		Predictors:     pps,
+		ArgFlags:       flagNamesWithHyphens(flags.argFlags...),
+		BoolFlags:      flagNamesWithHyphens(flags.boolFlags...),
+		LastIsVariadic: lastIsVariadic,
 	}
 
 	return &cmd, nil

--- a/prediction_test.go
+++ b/prediction_test.go
@@ -215,6 +215,79 @@ func Test_tagPredictor(t *testing.T) {
 	})
 }
 
+func TestCompleteCumulativeFlags(t *testing.T) {
+	t.Run("single cumulative arg", func(t *testing.T) {
+		predictors := map[string]complete.Predictor{
+			"sources": complete.PredictSet("src1", "src2", "src3"),
+		}
+
+		var cli struct {
+			Sources []string `kong:"arg,completion-predictor=sources"`
+		}
+
+		for _, td := range []completeTest{
+			{line: "myApp ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp src", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp src1 ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp src1 src2 ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp src1 src2 src3 ", want: []string{"src1", "src2", "src3"}},
+		} {
+			t.Run(td.line, func(t *testing.T) {
+				got := runComplete(t, kong.Must(&cli), td.line, []Option{WithPredictors(predictors)})
+				assert.ElementsMatch(t, td.want, got)
+			})
+		}
+	})
+
+	t.Run("cumulative and non-cumulative args mixed", func(t *testing.T) {
+		predictors := map[string]complete.Predictor{
+			"dests":   complete.PredictSet("dest1", "dest2"),
+			"sources": complete.PredictSet("src1", "src2", "src3"),
+		}
+
+		var cli struct {
+			Dest    string   `kong:"arg,completion-predictor=dests"`
+			Sources []string `kong:"arg,completion-predictor=sources"`
+		}
+
+		for _, td := range []completeTest{
+			{line: "myApp ", want: []string{"dest1", "dest2"}},
+			{line: "myApp dest1 ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp dest1 src1 ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp dest1 src1 src2 ", want: []string{"src1", "src2", "src3"}},
+		} {
+			t.Run(td.line, func(t *testing.T) {
+				got := runComplete(t, kong.Must(&cli), td.line, []Option{WithPredictors(predictors)})
+				assert.ElementsMatch(t, td.want, got)
+			})
+		}
+	})
+
+	t.Run("cumulative and non-cumulative flag mixed", func(t *testing.T) {
+		predictors := map[string]complete.Predictor{
+			"sources": complete.PredictSet("src1", "src2", "src3"),
+		}
+
+		var cli struct {
+			Verbose bool     `kong:""`
+			Sources []string `kong:"arg,completion-predictor=sources"`
+		}
+
+		for _, td := range []completeTest{
+			{line: "myApp ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp --verbose ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp src1 ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp --verbose src1 ", want: []string{"src1", "src2", "src3"}},
+			{line: "myApp src1 --verbose src2 ", want: []string{"src1", "src2", "src3"}},
+		} {
+			t.Run(td.line, func(t *testing.T) {
+				got := runComplete(t, kong.Must(&cli), td.line, []Option{WithPredictors(predictors)})
+				assert.ElementsMatch(t, td.want, got)
+			})
+		}
+	})
+}
+
 type testTag map[string]string
 
 func (t testTag) Has(k string) bool {
@@ -272,77 +345,6 @@ func runComplete(t *testing.T, parser *kong.Kong, line string, options []Option)
 	}
 	Register(parser, options...)
 	return parseOutput(buf.String())
-}
-
-func TestComplete_variadic_only(t *testing.T) {
-	predictors := map[string]complete.Predictor{
-		"sources": complete.PredictSet("src1", "src2", "src3"),
-	}
-
-	var cli struct {
-		Sources []string `kong:"arg,completion-predictor=sources"`
-	}
-
-	for _, td := range []completeTest{
-		{line: "myApp ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp src", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp src1 ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp src1 src2 ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp src1 src2 src3 ", want: []string{"src1", "src2", "src3"}},
-	} {
-		t.Run(td.line, func(t *testing.T) {
-			got := runComplete(t, kong.Must(&cli), td.line, []Option{WithPredictors(predictors)})
-			assert.ElementsMatch(t, td.want, got)
-		})
-	}
-}
-
-func TestComplete_variadic_mixed(t *testing.T) {
-	predictors := map[string]complete.Predictor{
-		"dests":   complete.PredictSet("dest1", "dest2"),
-		"sources": complete.PredictSet("src1", "src2", "src3"),
-	}
-
-	var cli struct {
-		Dest    string   `kong:"arg,completion-predictor=dests"`
-		Sources []string `kong:"arg,completion-predictor=sources"`
-	}
-
-	for _, td := range []completeTest{
-		{line: "myApp ", want: []string{"dest1", "dest2"}},
-		{line: "myApp dest1 ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp dest1 src1 ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp dest1 src1 src2 ", want: []string{"src1", "src2", "src3"}},
-	} {
-		t.Run(td.line, func(t *testing.T) {
-			got := runComplete(t, kong.Must(&cli), td.line, []Option{WithPredictors(predictors)})
-			assert.ElementsMatch(t, td.want, got)
-		})
-	}
-}
-
-func TestComplete_variadic_with_flags(t *testing.T) {
-	predictors := map[string]complete.Predictor{
-		"sources": complete.PredictSet("src1", "src2", "src3"),
-	}
-
-	var cli struct {
-		Verbose bool     `kong:""`
-		Sources []string `kong:"arg,completion-predictor=sources"`
-	}
-
-	for _, td := range []completeTest{
-		{line: "myApp ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp --verbose ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp src1 ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp --verbose src1 ", want: []string{"src1", "src2", "src3"}},
-		{line: "myApp src1 --verbose src2 ", want: []string{"src1", "src2", "src3"}},
-	} {
-		t.Run(td.line, func(t *testing.T) {
-			got := runComplete(t, kong.Must(&cli), td.line, []Option{WithPredictors(predictors)})
-			assert.ElementsMatch(t, td.want, got)
-		})
-	}
 }
 
 func parseOutput(output string) []string {


### PR DESCRIPTION
`PositionalPredictor.predictorIndex()` counts each completed positional arg and uses that as an index into the `Predictors` slice. For a variadic `[]string` arg, Kong creates only one entry in `node.Positional`, so there is one predictor. After the first value, the index exceeds the slice length and `predictor()` returns nil — no completions for subsequent values.

This PR adds `LastIsVariadic` to `PositionalPredictor`. When `true` and the index exceeds the slice, clamp to the last predictor instead of returning `nil`. Detect cumulative positionals via Kong's `IsCumulative()` in `nodeCommand()`.